### PR TITLE
Add webpack v4 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,22 @@
 
 const juice = require('juice');
 
-function HtmlWebpackInlinerPlugin (options) {
+function HtmlWebpackInlinerPlugin(options) {
     // Initialize
 }
 
 HtmlWebpackInlinerPlugin.prototype.apply = compiler => {
-	compiler.plugin('compilation', compilation => {
-		compilation.plugin('html-webpack-plugin-after-html-processing', (htmlPluginData, callback) => {
-			htmlPluginData.html = juice(htmlPluginData.html);
-			callback(null, htmlPluginData);
-		});
-	});
+    (compiler.hooks
+        ? compiler.hooks.compilation.tap.bind(compiler.hooks.compilation, 'html-webpack-inline-style-plugin')
+        : compiler.plugin.bind(compiler, 'compilation'))(compilation => {
+
+        (compilation.hooks
+            ? compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync.bind(compilation.hooks.htmlWebpackPluginAfterHtmlProcessing, 'html-webpack-inline-style-plugin')
+            : compilation.plugin.bind(compilation, 'html-webpack-plugin-after-html-processing'))((htmlPluginData, callback) => {
+            htmlPluginData.html = juice(htmlPluginData.html);
+            callback(null, htmlPluginData);
+        });
+    });
 };
 
 module.exports = HtmlWebpackInlinerPlugin;


### PR DESCRIPTION
As webpack v4 has a new plugin system now the `Compiler.hooks.xxx.tap(<plugin name>, fn)` should be used instead.

This should fix https://github.com/djaax/html-webpack-inline-style-plugin/issues/1.
