### PR TITLE
Add support for juice options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,19 @@ Add the plugin to your webpack config as follows:
 	...
 }
 ```
+
+With [Juice options](https://www.npmjs.com/package/juice#options):
+
+```javascript
+{
+	...
+	plugins: [
+	  new HtmlWebpackPlugin(),
+	  new HtmlWebpackInlineStylePlugin({
+	    juiceOptions: {
+	      removeStyleTags: false
+	    }
+	  })
+	]
+	...
+}

--- a/index.js
+++ b/index.js
@@ -2,8 +2,11 @@
 
 const juice = require('juice');
 
+let juiceOptions;
+
 function HtmlWebpackInlinerPlugin(options) {
     // Initialize
+    juiceOptions = options.juiceOptions || {};
 }
 
 HtmlWebpackInlinerPlugin.prototype.apply = compiler => {
@@ -14,7 +17,7 @@ HtmlWebpackInlinerPlugin.prototype.apply = compiler => {
         (compilation.hooks
             ? compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync.bind(compilation.hooks.htmlWebpackPluginAfterHtmlProcessing, 'html-webpack-inline-style-plugin')
             : compilation.plugin.bind(compilation, 'html-webpack-plugin-after-html-processing'))((htmlPluginData, callback) => {
-            htmlPluginData.html = juice(htmlPluginData.html);
+            htmlPluginData.html = juice(htmlPluginData.html, juiceOptions);
             callback(null, htmlPluginData);
         });
     });


### PR DESCRIPTION
Hey @djaax, Hope all is well with yourself. 

This PR Fixes #4 by adding support for passing juice options.

I am not the reporter of #4 but I ran into the same issue when wanting to use this plugin for an email template project. Our current setup uses juice and requires various flags.

Have tested it in said email template project and works really well.