### PR TITLE
Add support for html-webpack-plugin >= 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+node_modules

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "homepage": "https://github.com/djaax/html-webpack-inline-style-plugin",
   "dependencies": {
     "juice": "^4.2.2"
+  },
+  "devDependencies": {
+    "html-webpack-plugin": "^4.3.0"
   }
 }


### PR DESCRIPTION
Hi, @djaax  this PR did: 

- Add html-webpack-plugin (v4+) compatibility support (https://github.com/jantimon/html-webpack-plugin/blob/master/CHANGELOG.md#breaking-changes)
- Fix options undefined bug
- Refactor